### PR TITLE
Fix V575 warning from PVS-Studio Static Analyzer

### DIFF
--- a/vt100.c
+++ b/vt100.c
@@ -178,7 +178,7 @@ void _vt100_scroll(struct vt100 *t, int16_t lines){
 		// scrolling up so clear first line of scroll area
 		//uint16_t y = (t->scroll_start_row + t->scroll_value) * VT100_CHAR_HEIGHT; 
 		//ili9340_fillRect(0, y, VT100_SCREEN_WIDTH, lines * VT100_CHAR_HEIGHT, 0x0000);
-	} else if(lines < 0){
+	} else {
 		_vt100_clearLines(t, t->scroll_end_row - lines, t->scroll_end_row - 1); 
 		// make sure that the value wraps down 
 		t->scroll_value = (scroll_height + t->scroll_value + lines) % scroll_height; 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
V547 Expression 'lines < 0' is always true. vt100.c:181
